### PR TITLE
Add change attribute functionality

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['7.2', '7.3', '7.4', '8.0']
+        php: ['7.3', '7.4', '8.0']
         stability: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.stability }}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": "^7.2.5 || ^8.0",
+    "php": "^7.3 || ^8.0",
     "ext-json": "*",
     "ext-ldap": "*",
     "ext-openssl": "*",

--- a/src/Client.php
+++ b/src/Client.php
@@ -17,6 +17,9 @@ use Symfony\Component\Ldap\LdapInterface;
 
 class Client implements OAuthClientInterface
 {
+    const ACCOUNT_ENABLED = 0x0200;
+    const ACCOUNT_DISABLED = 0x0002;
+
     /**
      * Alternative to using custom object classes in LDAP.
      * Will translate attributes passed to this object's methods ($attributes).
@@ -94,7 +97,7 @@ class Client implements OAuthClientInterface
      */
     protected function throwIfAccountDisabled(ResourceOwnerInterface $user): void
     {
-        if (Arr::first($user['userAccountControl']) === '2') {
+        if (Arr::first($user['userAccountControl']) === (string) self::ACCOUNT_DISABLED) {
             throw new ClientException('Account disabled.');
         }
     }
@@ -182,7 +185,7 @@ class Client implements OAuthClientInterface
      */
     public function enableUser(string $identifier): bool
     {
-        $this->changeAttribute($identifier, 'userAccountControl', '0');
+        $this->changeAttribute($identifier, 'userAccountControl', (string) self::ACCOUNT_ENABLED);
 
         return true;
     }
@@ -192,7 +195,7 @@ class Client implements OAuthClientInterface
      */
     public function disableUser(string $identifier): bool
     {
-        $this->changeAttribute($identifier, 'userAccountControl', '2');
+        $this->changeAttribute($identifier, 'userAccountControl', (string) self::ACCOUNT_DISABLED);
 
         return true;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,13 +6,26 @@ use Dvsa\Contracts\Auth\AccessTokenInterface;
 use Dvsa\Contracts\Auth\Exceptions\ClientException;
 use Dvsa\Contracts\Auth\OAuthClientInterface;
 use Dvsa\Contracts\Auth\ResourceOwnerInterface;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+use Symfony\Component\Ldap\Adapter\ExtLdap\UpdateOperation;
 use Symfony\Component\Ldap\Entry;
 use Symfony\Component\Ldap\Exception\ExceptionInterface;
+use Symfony\Component\Ldap\Exception\LdapException;
 use Symfony\Component\Ldap\LdapInterface;
 
 class Client implements OAuthClientInterface
 {
+    /**
+     * Alternative to using custom object classes in LDAP.
+     * Will translate attributes passed to this object's methods ($attributes).
+     *
+     * ['attribute_key_1' => 'ldap_mapped_attribute', ...]
+     *
+     * @var array
+     */
+    public static $attributeMap = [];
+
     /**
      * @var LdapInterface
      */
@@ -34,16 +47,24 @@ class Client implements OAuthClientInterface
     protected $secret;
 
     /**
+     * @var array
+     */
+    protected $objectClass;
+
+    /**
      * Ldap Client constructor.
      *
-     * @param  LdapInterface  $ldap
-     * @param  string         $baseDn
-     * @param  string         $secret key to sign the JWT
+     * @param  LdapInterface $ldap
+     * @param  string $baseDn
+     * @param  array  $objectClass  without extension of the `register` method, the object classes provided must
+     *                              have the attributes: `userPassword` & `userAccountControl`
+     * @param  string $secret key to sign the JWT
      */
-    public function __construct(LdapInterface $ldap, string $baseDn, string $secret)
+    public function __construct(LdapInterface $ldap, string $baseDn, array $objectClass, string $secret)
     {
         $this->ldap = $ldap;
         $this->baseDn = $baseDn;
+        $this->objectClass = $objectClass;
         $this->secret = $secret;
     }
 
@@ -55,7 +76,6 @@ class Client implements OAuthClientInterface
         $dn = $this->buildDn($identifier);
 
         try {
-            // Try the bind with the username/password combination.
             $this->bind($dn, $password);
         } catch (ExceptionInterface $e) {
             throw new ClientException($e->getMessage(), (int) $e->getCode(), $e);
@@ -63,7 +83,16 @@ class Client implements OAuthClientInterface
 
         $user = $this->getUserByIdentifier($identifier);
 
+        $this->throwIfAccountDisabled($user);
+
         return $this->generateToken($user);
+    }
+
+    protected function throwIfAccountDisabled(ResourceOwnerInterface $user): void
+    {
+        if (Arr::first($user->get('userAccountControl')) === 2) {
+            throw new ClientException('Account disabled.');
+        }
     }
 
     /**
@@ -76,9 +105,9 @@ class Client implements OAuthClientInterface
         $formattedAttributes = $this->formatAttributes($attributes);
 
         $ldapAttributes = array_merge([
-            'objectClass' => ['inetOrgPerson'],
+            'objectClass' => $this->objectClass,
             'userPassword' => [$this->generatePassword($password)],
-            'sn' => [$identifier],
+            'userAccountControl' => [0],
         ], $formattedAttributes);
 
         $entry = new Entry($dn, $ldapAttributes);
@@ -99,7 +128,7 @@ class Client implements OAuthClientInterface
      */
     public function changePassword(string $identifier, string $newPassword): bool
     {
-        // TODO: Implement changePassword() method.
+        return $this->changeAttributes($identifier, ['userPassword' => $this->generatePassword($newPassword)]);
     }
 
     /**
@@ -107,7 +136,7 @@ class Client implements OAuthClientInterface
      */
     public function changeAttribute(string $identifier, string $key, string $value): bool
     {
-        // TODO: Implement changeAttribute() method.
+        return $this->changeAttributes($identifier, [$key => $value]);
     }
 
     /**
@@ -115,7 +144,27 @@ class Client implements OAuthClientInterface
      */
     public function changeAttributes(string $identifier, array $attributes): bool
     {
-        // TODO: Implement changeAttributes() method.
+        $formattedAttributes = $this->formatAttributes($attributes);
+
+        $operations = [];
+
+        foreach ($formattedAttributes as $key => $value) {
+            $operations[$key] = new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, $key, Arr::wrap($value));
+        }
+
+        try {
+            $entryManager = $this->ldap->getEntryManager();
+
+            $dn = $this->buildDn($identifier);
+
+            $entry = $this->getLdapEntry($dn);
+
+            $entryManager->applyOperations($entry->getDn(), $operations);
+        } catch (ExceptionInterface $e) {
+            throw new ClientException($e->getMessage(), (int) $e->getCode(), $e);
+        }
+
+        return true;
     }
 
     /**
@@ -123,7 +172,9 @@ class Client implements OAuthClientInterface
      */
     public function enableUser(string $identifier): bool
     {
-        // TODO: Implement enableUser() method.
+        $this->changeAttribute($identifier, 'userAccountControl', 0);
+
+        return true;
     }
 
     /**
@@ -131,7 +182,9 @@ class Client implements OAuthClientInterface
      */
     public function disableUser(string $identifier): bool
     {
-        // TODO: Implement disableUser() method.
+        $this->changeAttribute($identifier, 'userAccountControl', 2);
+
+        return true;
     }
 
     /**
@@ -178,21 +231,25 @@ class Client implements OAuthClientInterface
     {
         $dn = $this->buildDn($identifier);
 
-        $query = $this->ldap->query($dn, '(objectClass=inetOrgPerson)');
-        $entry = $query->execute();
+        $user = $this->getLdapEntry($dn);
 
-        if (empty($entry)) {
-            throw new ClientException('User not found.');
-        }
-
-        $user = $entry[0];
-
-        $attributes = [
+        $attributes = array_merge([
             'dn' => $user->getDn(),
-            'cn' => $user->getAttribute('cn'),
-        ];
+        ], $user->getAttributes());
 
         return new LdapUser($attributes);
+    }
+
+    protected function getLdapEntry(string $dn): Entry
+    {
+        try {
+            $query = $this->ldap->query($dn, '(objectClass=*)');
+            $entry = $query->execute();
+
+            return $entry[0];
+        } catch (LdapException $e) {
+            throw new ClientException($e->getMessage(), (int) $e->getCode(), $e);
+        }
     }
 
     public function setTokenFactory(TokenFactoryInterface $factory): self
@@ -236,7 +293,6 @@ class Client implements OAuthClientInterface
 
         $options['access_token'] = $tokenFactory->make($entry['dn'], ['username' => $entry['dn']]);
         $options['id_token'] = $tokenFactory->make($entry['dn'], $entry->toArray());
-        $options['refresh_token'] = Str::random(32);
         $options['expires_in'] = $tokenFactory->getExpiresIn();
 
         return new AccessToken($options);
@@ -254,9 +310,35 @@ class Client implements OAuthClientInterface
         $formatted = [];
 
         foreach ($attributes as $key => $value) {
-            $formatted["x-" . $key] = is_array($value) ? $value : [$value];
+            if (isset(self::$attributeMap[$key])) {
+                $formatted[self::$attributeMap[$key]] = $this->formatAttributeValue($value);
+
+                continue;
+            }
+
+            // If the key exists but is null, ignore it.
+            if (array_key_exists($key, self::$attributeMap)) {
+                continue;
+            }
+
+            $formatted[$key] = $this->formatAttributeValue($value);
         }
 
         return $formatted;
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    protected function formatAttributeValue($value): array
+    {
+        // https://datatracker.ietf.org/doc/html/rfc4517#section-3.3.3
+        if (is_bool($value)) {
+            $value = ($value ? 'TRUE' : 'FALSE');
+        }
+
+        return Arr::wrap($value);
     }
 }

--- a/src/LdapUser.php
+++ b/src/LdapUser.php
@@ -3,6 +3,7 @@
 namespace Dvsa\Authentication\Ldap;
 
 use Dvsa\Contracts\Auth\AbstractResourceOwner;
+use Illuminate\Support\Arr;
 
 /**
  * A Resource owner object, containing helper methods for non-custom attributes.
@@ -11,17 +12,8 @@ use Dvsa\Contracts\Auth\AbstractResourceOwner;
  */
 class LdapUser extends AbstractResourceOwner
 {
-    public function __construct(array $attributes = [])
-    {
-        if (isset($attributes['dn'])) {
-            throw new \RuntimeException('The resource owner must have a `dn` attribute.');
-        }
-
-        parent::__construct($attributes);
-    }
-
     public function getId(): string
     {
-        return $this->get('dn');
+        return Arr::first($this->get('cn'));
     }
 }

--- a/tests/ContractExceptionsAreThrownInsteadTest.php
+++ b/tests/ContractExceptionsAreThrownInsteadTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dvsa\Authentication\Cognito\Tests;
+namespace Dvsa\Authentication\Ldap\Tests;
 
 use Dvsa\Authentication\Ldap\Client;
 use Dvsa\Contracts\Auth\Exceptions\ClientException;
@@ -64,16 +64,6 @@ class ContractExceptionsAreThrownInsteadTest extends TestCase
         yield ['changeAttributes', ['IDENTIFIER', []]];
         yield ['enableUser', ['IDENTIFIER']];
         yield ['disableUser', ['IDENTIFIER']];
-    }
-
-    public function testGetUserWillThrowErrorWhenFindingNonExistentUser(): void
-    {
-        $queryMock = $this->createMock(QueryInterface::class);
-
-        $this->mockLdap->method('query')->willReturn($queryMock);
-
-        $this->expectException(ClientException::class);
-
-        $this->client->getUserByIdentifier('IDENTIFIER');
+        yield ['getUserByIdentifier', ['IDENTIFIER']];
     }
 }

--- a/tests/ContractExceptionsAreThrownInsteadTest.php
+++ b/tests/ContractExceptionsAreThrownInsteadTest.php
@@ -38,7 +38,7 @@ class ContractExceptionsAreThrownInsteadTest extends TestCase
 
         $this->mockLdap->method('getEntryManager')->willReturn($this->mockEntryManager);
 
-        $this->client = new Client($this->mockLdap, 'BASE_DN', 'SECRET');
+        $this->client = new Client($this->mockLdap, 'BASE_DN', ['OBJECT_CLASS'], 'SECRET');
     }
 
     /**
@@ -47,6 +47,7 @@ class ContractExceptionsAreThrownInsteadTest extends TestCase
     public function testMethodsWillThrowContractedException(string $method, array $args = []): void
     {
         $this->mockLdap->method('bind')->willThrowException(new ConnectionException);
+        $this->mockLdap->method('query')->willThrowException(new LdapException);
         $this->mockEntryManager->method(new IsAnything)->willThrowException(new LdapException);
 
         $this->expectException(ClientException::class);

--- a/tests/FormatAttributesTest.php
+++ b/tests/FormatAttributesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dvsa\Authentication\Cognito\Tests;
+namespace Dvsa\Authentication\Ldap\Tests;
 
 use Dvsa\Authentication\Ldap\Client;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/FormatAttributesTest.php
+++ b/tests/FormatAttributesTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Dvsa\Authentication\Cognito\Tests;
+
+use Dvsa\Authentication\Ldap\Client;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Ldap\Adapter\EntryManagerInterface;
+use Symfony\Component\Ldap\Adapter\ExtLdap\EntryManager;
+use Symfony\Component\Ldap\Adapter\ExtLdap\UpdateOperation;
+use Symfony\Component\Ldap\Adapter\QueryInterface;
+use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\LdapInterface;
+
+class FormatAttributesTest extends TestCase
+{
+    /**
+     * @var MockObject|EntryManagerInterface
+     */
+    protected $mockEntryManager;
+
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    protected function setUp(): void
+    {
+        $this->mockEntryManager = $this->createMock(EntryManager::class);
+
+        $mockLdap = $this->createMock(LdapInterface::class);
+        $mockLdap->method('getEntryManager')->willReturn($this->mockEntryManager);
+
+        $mockQuery = $this->createMock(QueryInterface::class);
+        $mockQuery->method('execute')->willReturn([
+            new Entry('cn=PHPUnit,dc=local', [])
+        ]);
+
+        $mockLdap->method('query')->willReturn($mockQuery);
+
+        $this->client = new Client($mockLdap, 'BASE_DN', ['OBJECT_CLASS'], 'SECRET');
+    }
+
+    /**
+     * @dataProvider providesAttributesAndResultingOperations
+     */
+    public function testAttributesAreFormattedCorrectly(array $before, array $after, array $map = []): void
+    {
+        $this->client::$attributeMap = $map;
+
+        $this->mockEntryManager
+            ->method('applyOperations')
+            ->will($this->returnCallback(function ($dn, $operations) use ($after) {
+                $this->assertEquals($after, array_values($operations));
+            }));
+
+        $this->client->changeAttributes('IDENTIFIER', $before);
+    }
+
+    public function providesAttributesAndResultingOperations(): \Generator
+    {
+        yield 'Ensure attributes are translated to `UpdateOperation` objects' => [
+            ['ATTRIBUTE_1' => 'VALUE_1', 'ATTRIBUTE_2' => 'VALUE_2'],
+            [
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_1', ['VALUE_1']),
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_2', ['VALUE_2']),
+            ],
+        ];
+
+        yield 'Ensure attribute removed if mapped to null' => [
+            ['ATTRIBUTE_1' => 'VALUE_1', 'ATTRIBUTE_2' => 'VALUE_2', 'ATTRIBUTE_3' => 'VALUE_3'],
+            [
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_1', ['VALUE_1']),
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_2', ['VALUE_2']),
+            ],
+            ['ATTRIBUTE_3' => null, ],
+        ];
+
+        yield 'Ensure attribute renamed if mapped to a different key' => [
+            ['ATTRIBUTE_1' => 'VALUE_1', 'ATTRIBUTE_2' => 'VALUE_2', ],
+            [
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_1', ['VALUE_1']),
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'RENAMED_ATTRIBUTE_2', ['VALUE_2']),
+            ],
+            ['ATTRIBUTE_2' => 'RENAMED_ATTRIBUTE_2', ],
+        ];
+
+        yield 'Ensure bool attribute translated to string' => [
+            ['ATTRIBUTE_1' => false, 'ATTRIBUTE_2' => true, ],
+            [
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_1', ['FALSE']),
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_2', ['TRUE']),
+            ],
+        ];
+    }
+}

--- a/tests/TokenFactoryTest.php
+++ b/tests/TokenFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dvsa\Authentication\Cognito\Tests;
+namespace Dvsa\Authentication\Ldap\Tests;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;


### PR DESCRIPTION
<!--
Ensure you have read the Contributing Guide and Code of Conduct, and:
 - Added tests covering the introduced code and ensure they pass.
 - Have not broke backward compatibility.
-->

| Q                | A
| ---------------- | ---
| Type             | Feature
| Ticket           | BL-12360 & BL-12361

**Description of the change:**
<!-- Replace this with a short description of what the PR includes. -->
Implement methods to `changePassword` and `changeAttributes`


Due to dependencies I've removed PHP 7.2 support - If we need it, I can look into tweaking the dependencies to support this. Problem dependency is: `illuminate/support`.

Running it locally: 

Directory Structure
```
localdev
   |
   |--> ldap-schema
   |          |
   |          |--> user.schema
   |
   |--> docker-composer.yaml
```

`.schema` used:
```
attributetype ( 1.2.840.113556.1.4.8 NAME 'userAccountControl'
    SYNTAX '1.3.6.1.4.1.1466.115.121.1.27' )

attributetype ( 1.2.840.113556.1.4.9 NAME 'emailVerified'
    EQUALITY booleanMatch
    SYNTAX '1.3.6.1.4.1.1466.115.121.1.7' )

objectclass ( 1.2.840.113556.1.5.9 NAME 'user'
        DESC 'a user'
        MUST ( cn )
        MAY ( sn $ userPassword $ mail $ distinguishedName $ userAccountControl $ emailVerified ) )
```

`docker-compose.yaml` for local LDAP instance:
```
openldap:
    image: osixia/openldap:latest
    container_name: openldap
    environment:
      LDAP_LOG_LEVEL: "512"
      LDAP_ORGANISATION: "DVSA"
      LDAP_DOMAIN: "localdev.dvsa"
      LDAP_TLS_VERIFY_CLIENT: "allow"
    volumes:
      - ./ldap-schema:/container/service/slapd/assets/config/bootstrap/schema/custom
    ports:
      - "389:389"
      - "636:636"
    command: "--copy-service --loglevel trace"
```
