### PR TITLE
Use the new `CreatesResourceOwners` trait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-json": "*",
     "ext-ldap": "*",
     "ext-openssl": "*",
-    "dvsa/contracts": "^1",
+    "dvsa/contracts": "^1.1",
     "firebase/php-jwt": "^5.2",
     "illuminate/support": "^6.20 || ^8.49",
     "league/oauth2-client": "^2.6",


### PR DESCRIPTION
<!--
Ensure you have read the Contributing Guide and Code of Conduct, and:
 - Added tests covering the introduced code and ensure they pass.
 - Have not broke backward compatibility.
-->

**Description of the change:**
<!-- Replace this with a short description of what the PR includes. -->
Uses the new trait introduced in https://github.com/dvsa/contracts/pull/13 to provide the ability to specify custom resource owner objects.