### PR TITLE
Tweak username claim value to be `cn` instead of `dn`

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -304,7 +304,7 @@ class Client implements OAuthClientInterface
 
         $tokenFactory = $this->getTokenFactory();
 
-        $options['access_token'] = $tokenFactory->make($entry['dn'], ['username' => $entry['dn']]);
+        $options['access_token'] = $tokenFactory->make($entry['dn'], ['username' => Arr::first($entry['cn'])]);
         $options['id_token'] = $tokenFactory->make($entry['dn'], $entry->toArray());
         $options['expires_in'] = $tokenFactory->getExpiresIn();
 


### PR DESCRIPTION
**Description of the change:**
<!-- Replace this with a short description of what the PR includes. -->
Changes the username field value used while building the access token. Previously, we set this as the `dn` field, but this can be attained by other means already, the `cn` would be next most useful value to enable username-matching within apps.
