### PR TITLE
Add date handling for attributes

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -352,6 +352,11 @@ class Client implements OAuthClientInterface
             $value = ($value ? 'TRUE' : 'FALSE');
         }
 
+        // https://datatracker.ietf.org/doc/html/rfc4517#section-3.3.13
+        if ($value instanceof \DateTimeInterface) {
+            $value = $value->format('YmdHis.v\Z');
+        }
+
         return Arr::wrap($value);
     }
 }

--- a/tests/FormatAttributesTest.php
+++ b/tests/FormatAttributesTest.php
@@ -92,5 +92,14 @@ class FormatAttributesTest extends TestCase
                 new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_2', ['TRUE']),
             ],
         ];
+
+        $date = new \DateTime();
+
+        yield 'Ensure date attribute translated to string' => [
+            ['ATTRIBUTE_1' => $date, ],
+            [
+                new UpdateOperation(LDAP_MODIFY_BATCH_REPLACE, 'ATTRIBUTE_1', [$date->format('YmdHis.v\Z')]),
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Similar to: https://github.com/dvsa/authentication-cognito/pull/16

<!--
Ensure you have read the Contributing Guide and Code of Conduct, and:
 - Added tests covering the introduced code and ensure they pass.
 - Have not broke backward compatibility.
-->

| Q                | A
| ---------------- | ---
| Type             | Feature

**Description of the change:**
<!-- Replace this with a short description of what the PR includes. -->

This PR will allow `DateTime` objects to be passed to `register` or `changeAttributes` to be formatted per the vendor's requirements. This requirement is bespoke and is different for all 3 of our adapters, which is why it seems better to handle the dates within this class.