### PR TITLE
feat: allow firebase/php-jwt ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ext-ldap": "*",
     "ext-openssl": "*",
     "dvsa/contracts": "^1.3",
-    "firebase/php-jwt": "^6.3",
+    "firebase/php-jwt": "^6.3 || ^7.0",
     "illuminate/support": "^8.49 || ^11.0",
     "league/oauth2-client": "^2.6.1",
     "nesbot/carbon": "^2.63 || ^3.4",


### PR DESCRIPTION
**Description of the change:**
Allow firebase/php-jwt 7.0 which enforces suitable length keys so consumers of this repo can update and dismiss security alerts
